### PR TITLE
Updated Notification Badge

### DIFF
--- a/background.html
+++ b/background.html
@@ -13,6 +13,7 @@
 <script type="text/javascript" src="/js/modules/capture_moments/capture_backend.js"></script>
 <script type="text/javascript" src="/js/modules/circle_notifier/circle_notifier.js"></script>
 <script type="text/javascript" src="/js/modules/maps/map_backend.js"></script>
+<script type="text/javascript" src="/js/canvascontext_extension.js"></script>
 <script type="text/javascript" src="/js/hangout_updater.js"></script>
 <script type="text/javascript" src="/js/background_controller.js"></script>
 <script type="text/javascript">

--- a/js/background_controller.js
+++ b/js/background_controller.js
@@ -126,48 +126,15 @@ BackgroundController.prototype.drawBadgeIcon = function(count, newItem) {
   // regardless of newItem's value
   newItem = newItem & (count > 0);
   
-  /**
-   * Private method which fills a rectangle that has rounded corners
-   * Used to imitate style of the Google+ Notification icon
-   *
-   * TOTHINK: Maybe this method should be defined somewhere else...
-   * A possibility would be to extend the canvas context prototype
-   * by seperate methods for filling and stroking in order to keep a 
-   * consistent interface.
-   *
-   * @param {Object} context The canvas context on which to draw.
-   * @param {number} x The x-coordinate of the upper left corner of the 
-   * desired rounded rectangle
-   * @param {number} y The y-coordinate of the upper left corner of the
-   * desired rounded rectangle
-   * @param {number} width The desired rectangle's width.
-   * @param {number} height The desired rectangle's height.
-   * @param {number} radius The radius with which the corners should be rounded
-   */
-  var fillAndStrokeRoundRect = function(context, x, y, width, height, radius) {
-    context.beginPath();
-    // Let's start in the upper left corner of the shape and draw clockwise
-    context.moveTo(x + radius, y);
-    context.lineTo(x + width - radius, y);
-    context.quadraticCurveTo(x + width, y, x + width, y + radius);
-    context.lineTo(x + width, y + height - radius);
-    context.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
-    context.lineTo(x + radius, y + height);
-    context.quadraticCurveTo(x, y + height, x, y + height - radius);
-    context.lineTo(x, y + radius);
-    context.quadraticCurveTo(x, y, x + radius, y);
-    context.fill();
-    context.stroke();
-  }
-
   if (newItem) {
     ctx.fillStyle = 'rgba(48, 121, 237, 1)';
     ctx.strokeStyle = 'rgba(43, 108, 212, 0.5)';
     
     // Sadly, the fix below makes the active badge look not like the original
-    // one - therefore we have to have two different fill calls (with 
+    // one - therefore we have to have two different fill and stroke calls (with 
     // different coordinates)
-    fillAndStrokeRoundRect(ctx, 0, 0, 19, 19, 2);
+    ctx.fillRoundRect(0, 0, 19, 19, 2);
+    ctx.strokeRoundRect(0, 0, 19, 19, 2);
   }
   else {
     ctx.fillStyle = 'rgba(237, 237, 237, 1)';
@@ -176,13 +143,14 @@ BackgroundController.prototype.drawBadgeIcon = function(count, newItem) {
     // We are offsetting the rectangle by half a unit in order to achieve a 
     // crisp border on the inactive badge (see characteristics of lineWidth: 
     // http://goo.gl/DFnaA)
-    fillAndStrokeRoundRect(ctx, 0.5, 0.5, 18, 18, 2);
+    ctx.fillRoundRect(0.5, 0.5, 18, 18, 2);
+    ctx.strokeRoundRect(0.5, 0.5, 18, 18, 2);
   }
 
   ctx.font = 'bold 11px arial, sans-serif';
   ctx.fillStyle = newItem ? '#fff' : '#999';
 
-  chrome.browserAction.setTitle({title: 'There are ' + count + ' people hanging out!'});
+  chrome.browserAction.setTitle({title: count + ' hangouts are going on right now!'});
   if (count > 19){
     ctx.fillText('19+', 1, 14);
   }
@@ -190,7 +158,10 @@ BackgroundController.prototype.drawBadgeIcon = function(count, newItem) {
     ctx.fillText(count + '', 3, 14);
   }
   else if (count >= 0) {
-    ctx.fillText(count + '', 6.5, 14);
+    ctx.fillText(count + '', 6, 14);
+    if ( count == 0 ){
+      chrome.browserAction.setTitle({title: 'There are no hangouts going on!'});
+    }
   }
   else {
     ctx.fillText('?', 6, 14);

--- a/js/background_controller.js
+++ b/js/background_controller.js
@@ -122,6 +122,10 @@ BackgroundController.prototype.onMessageListener = function(request, sender, sen
 BackgroundController.prototype.drawBadgeIcon = function(count, newItem) {
   var ctx = document.createElement('canvas').getContext('2d');
 
+  // If count is zero or smaller, show the badge as inactive,
+  // regardless of newItem's value
+  newItem = newItem & (count > 0);
+  
   /**
    * Private method which fills a rectangle that has rounded corners
    * Used to imitate style of the Google+ Notification icon

--- a/js/background_controller.js
+++ b/js/background_controller.js
@@ -121,17 +121,64 @@ BackgroundController.prototype.onMessageListener = function(request, sender, sen
  */
 BackgroundController.prototype.drawBadgeIcon = function(count, newItem) {
   var ctx = document.createElement('canvas').getContext('2d');
+
+  /**
+   * Private method which fills a rectangle that has rounded corners
+   * Used to imitate style of the Google+ Notification icon
+   *
+   * TOTHINK: Maybe this method should be defined somewhere else...
+   * A possibility would be to extend the canvas context prototype
+   * by seperate methods for filling and stroking in order to keep a 
+   * consistent interface.
+   *
+   * @param {Object} context The canvas context on which to draw.
+   * @param {number} x The x-coordinate of the upper left corner of the 
+   * desired rounded rectangle
+   * @param {number} y The y-coordinate of the upper left corner of the
+   * desired rounded rectangle
+   * @param {number} width The desired rectangle's width.
+   * @param {number} height The desired rectangle's height.
+   * @param {number} radius The radius with which the corners should be rounded
+   */
+  var fillAndStrokeRoundRect = function(context, x, y, width, height, radius) {
+    context.beginPath();
+    // Let's start in the upper left corner of the shape and draw clockwise
+    context.moveTo(x + radius, y);
+    context.lineTo(x + width - radius, y);
+    context.quadraticCurveTo(x + width, y, x + width, y + radius);
+    context.lineTo(x + width, y + height - radius);
+    context.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+    context.lineTo(x + radius, y + height);
+    context.quadraticCurveTo(x, y + height, x, y + height - radius);
+    context.lineTo(x, y + radius);
+    context.quadraticCurveTo(x, y, x + radius, y);
+    context.fill();
+    context.stroke();
+  }
+
   if (newItem) {
     ctx.fillStyle = 'rgba(48, 121, 237, 1)';
+    ctx.strokeStyle = 'rgba(43, 108, 212, 0.5)';
+    
+    // Sadly, the fix below makes the active badge look not like the original
+    // one - therefore we have to have two different fill calls (with 
+    // different coordinates)
+    fillAndStrokeRoundRect(ctx, 0, 0, 19, 19, 2);
   }
   else {
-    ctx.fillStyle = 'rgba(208, 208, 208, 1)';
-  }
-  ctx.fillRect(0, 0, 19, 19);
-  ctx.font = 'bold 11px arial, sans-serif';
-  ctx.fillStyle = '#fff';
+    ctx.fillStyle = 'rgba(237, 237, 237, 1)';
+    ctx.strokeStyle = 'rgba(150, 150, 150, 0.4)';
 
-  chrome.browserAction.setTitle({title: count + ' hangouts are going on right now!'});
+    // We are offsetting the rectangle by half a unit in order to achieve a 
+    // crisp border on the inactive badge (see characteristics of lineWidth: 
+    // http://goo.gl/DFnaA)
+    fillAndStrokeRoundRect(ctx, 0.5, 0.5, 18, 18, 2);
+  }
+
+  ctx.font = 'bold 11px arial, sans-serif';
+  ctx.fillStyle = newItem ? '#fff' : '#999';
+
+  chrome.browserAction.setTitle({title: 'There are ' + count + ' people hanging out!'});
   if (count > 19){
     ctx.fillText('19+', 1, 14);
   }
@@ -139,10 +186,7 @@ BackgroundController.prototype.drawBadgeIcon = function(count, newItem) {
     ctx.fillText(count + '', 3, 14);
   }
   else if (count >= 0) {
-    ctx.fillText(count + '', 6, 14);
-    if ( count == 0 ){
-      chrome.browserAction.setTitle({title: 'There are no hangouts going on!'});
-    }
+    ctx.fillText(count + '', 6.5, 14);
   }
   else {
     ctx.fillText('?', 6, 14);

--- a/js/canvascontext_extension.js
+++ b/js/canvascontext_extension.js
@@ -1,0 +1,71 @@
+/**
+ * We're adding one private and two public methods to the
+ * CanvasRenderingContext2D prototype, which allow us to draw
+ * rounded rectangles.
+ *
+ * @author kaktus621@gmail.com (Martin Matysiak)
+ */
+
+
+/**
+ * Private method which creates the desired shape _without_ actually drawing it
+ * (by using fill() or stroke()). This method can be used internally to avoid
+ * duplicate code.
+ *
+ * @param {number} x The x-coordinate of the upper left corner of the
+ * desired rounded rectangle.
+ * @param {number} y The y-coordinate of the upper left corner of the
+ * desired rounded rectangle.
+ * @param {number} width The desired rectangle's width.
+ * @param {number} height The desired rectangle's height.
+ * @param {number} radius The radius with which the corners should be rounded.
+ */
+CanvasRenderingContext2D.prototype._createRoundRect = function(x, y, width, height, radius) {
+  this.beginPath();
+  // We start in the upper left corner of the shape and draw clockwise
+  this.moveTo(x + radius, y);
+  this.lineTo(x + width - radius, y);
+  this.quadraticCurveTo(x + width, y, x + width, y + radius);
+  this.lineTo(x + width, y + height - radius);
+  this.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+  this.lineTo(x + radius, y + height);
+  this.quadraticCurveTo(x, y + height, x, y + height - radius);
+  this.lineTo(x, y + radius);
+  this.quadraticCurveTo(x, y, x + radius, y);
+};
+
+
+/**
+ * Draws a filled rounded rectangle at (x, y) position whose size is determined
+ * by width and height. Additionally, the corners are rounded by radius.
+ *
+ * @param {number} x The x-coordinate of the upper left corner of the
+ * desired rounded rectangle.
+ * @param {number} y The y-coordinate of the upper left corner of the
+ * desired rounded rectangle.
+ * @param {number} width The desired rectangle's width.
+ * @param {number} height The desired rectangle's height.
+ * @param {number} radius The radius with which the corners should be rounded.
+ */
+CanvasRenderingContext2D.prototype.fillRoundRect = function(x, y, width, height, radius) {
+  this._createRoundRect(x, y, width, height, radius);
+  this.fill();
+};
+
+
+/**
+ * Paints a rounded rectangle at (x, y) whose size is determined by width and
+ * height using the current strokeStyle. The corners are rounded by radius.
+ *
+ * @param {number} x The x-coordinate of the upper left corner of the
+ * desired rounded rectangle.
+ * @param {number} y The y-coordinate of the upper left corner of the
+ * desired rounded rectangle.
+ * @param {number} width The desired rectangle's width.
+ * @param {number} height The desired rectangle's height.
+ * @param {number} radius The radius with which the corners should be rounded.
+ */
+CanvasRenderingContext2D.prototype.strokeRoundRect = function(x, y, width, height, radius) {
+  this._createRoundRect(x, y, width, height, radius);
+  this.stroke();
+};


### PR DESCRIPTION
I changed the looks of the notification badge a bit so that it looks like the original Google+ notification badge (i.e. rounded corners and a stroke around them, see images for comparison). Furthermore I made the badge being rendered as inactive whenever the count is a non-positive number (if this is not desired, make sure to set `newItem` to false when calling the method with a `count` of zero, I didn't look where the method gets called).

Please see the comments in my commit; maybe the method for drawing a rounded rectangle should be added to the Canvas context prototype somewhere else.

![Active Badges](http://files.k621.de/active.png)

![Inactive Badges](http://files.k621.de/inactive.png)
