### PR TITLE
Fix for Issue #25 and other small tweaks

### DIFF
--- a/background.html
+++ b/background.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html> 
 <html>
-<script type="text/javascript" src="http://maps.google.com/maps/api/js?key=AIzaSyDnMniG_y2Fo35Tw28QnR4OeUTVBMXIWi4&sensor=true"></script>
-<script type="text/javascript" src="/js/modules/options/settings.js"></script>
-<script type="text/javascript" src="/js/libs/jquery-1.7.1.min.js"></script>
-<script type="text/javascript" src="/js/libs/underscore-1.1.6.js"></script>
-<script type="text/javascript" src="/js/jsapi/jsapi_helper.js"></script>
-<script type="text/javascript" src="/js/jsapi/jsapi_abstract_database.js"></script>
-<script type="text/javascript" src="/js/jsapi/jsapi_database.js"></script>
-<script type="text/javascript" src="/js/jsapi/jsapi_for_google_plus.js"></script>
-<script type="text/javascript" src="/js/jsapi_database_override.js"></script>
-<script type="text/javascript" src="/js/modules/statistics/statistics_backend.js"></script>
-<script type="text/javascript" src="/js/modules/capture_moments/capture_backend.js"></script>
-<script type="text/javascript" src="/js/modules/circle_notifier/circle_notifier.js"></script>
-<script type="text/javascript" src="/js/modules/maps/map_backend.js"></script>
-<script type="text/javascript" src="/js/canvascontext_extension.js"></script>
-<script type="text/javascript" src="/js/hangout_updater.js"></script>
-<script type="text/javascript" src="/js/background_controller.js"></script>
-<script type="text/javascript">
+<script src="http://maps.google.com/maps/api/js?key=AIzaSyDnMniG_y2Fo35Tw28QnR4OeUTVBMXIWi4&sensor=true"></script>
+<script src="/js/modules/options/settings.js"></script>
+<script src="/js/libs/jquery-1.7.1.min.js"></script>
+<script src="/js/libs/underscore-1.1.6.js"></script>
+<script src="/js/jsapi/jsapi_helper.js"></script>
+<script src="/js/jsapi/jsapi_abstract_database.js"></script>
+<script src="/js/jsapi/jsapi_database.js"></script>
+<script src="/js/jsapi/jsapi_for_google_plus.js"></script>
+<script src="/js/jsapi_database_override.js"></script>
+<script src="/js/modules/statistics/statistics_backend.js"></script>
+<script src="/js/modules/capture_moments/capture_backend.js"></script>
+<script src="/js/modules/circle_notifier/circle_notifier.js"></script>
+<script src="/js/modules/maps/map_backend.js"></script>
+<script src="/js/canvascontext_extension.js"></script>
+<script src="/js/hangout_updater.js"></script>
+<script src="/js/background_controller.js"></script>
+<script>
   var controller = new BackgroundController();
   controller.init();
 </script>

--- a/capture_gallery.html
+++ b/capture_gallery.html
@@ -3,16 +3,16 @@
 <head>
   <title>My Hangouts</title>
   <link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
-  <link rel="stylesheet" type="text/css" href="/css/common.css" />
-  <link rel="stylesheet" type="text/css" href="/css/capture_gallery.css" />
-  <link rel="stylesheet" type="text/css" href="/css/lightbox.css" />
-  <script type="text/javascript" src="/js/libs/jquery-1.7.1.min.js"></script>
-  <script type="text/javascript" src="/js/libs/jquery.tmpl.min.js"></script>
-  <script type="text/javascript" src="/js/libs/jquery.timeago.js"></script> 
-  <script type="text/javascript" src="/js/libs/jquery.ui.slider.js"></script>
-  <script type="text/javascript" src="/js/libs/glfx.js"></script>
-  <script type="text/javascript" src="/js/modules/capture_moments/capture_gallery_filter.js"></script>
-  <script type="text/javascript" src="/js/modules/capture_moments/capture_gallery_controller.js"></script>
+  <link rel="stylesheet" href="/css/common.css" />
+  <link rel="stylesheet" href="/css/capture_gallery.css" />
+  <link rel="stylesheet" href="/css/lightbox.css" />
+  <script src="/js/libs/jquery-1.7.1.min.js"></script>
+  <script src="/js/libs/jquery.tmpl.min.js"></script>
+  <script src="/js/libs/jquery.timeago.js"></script> 
+  <script src="/js/libs/jquery.ui.slider.js"></script>
+  <script src="/js/libs/glfx.js"></script>
+  <script src="/js/modules/capture_moments/capture_gallery_filter.js"></script>
+  <script src="/js/modules/capture_moments/capture_gallery_controller.js"></script>
   
 </head>
 <body>

--- a/capture_preview.html
+++ b/capture_preview.html
@@ -2,10 +2,10 @@
 <html>
 <head>
   <link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
-  <link rel="stylesheet" type="text/css" href="/css/common.css" />
-  <link rel="stylesheet" type="text/css" href="/css/capture_preview.css" />
-  <script type="text/javascript" src="/js/libs/jquery-1.7.1.min.js"></script>
-  <script type="text/javascript" src="/js/modules/capture_moments/capture_preview_controller.js"></script>
+  <link rel="stylesheet" href="/css/common.css" />
+  <link rel="stylesheet" href="/css/capture_preview.css" />
+  <script src="/js/libs/jquery-1.7.1.min.js"></script>
+  <script src="/js/modules/capture_moments/capture_preview_controller.js"></script>
 </head>
 <body>
 <div id="crx_myhangouts">

--- a/css/popup.css
+++ b/css/popup.css
@@ -68,7 +68,7 @@ body, html {
 .popup-page {
   width: 100%;
   position: absolute;
-  left: 600px;
+  display:none;
   overflow-x: hidden;
 }
 

--- a/css/popup.css
+++ b/css/popup.css
@@ -1,7 +1,7 @@
 
 body, html {
   font: normal 13px arial,sans-serif;
-  margin-top: 0;
+  margin: 0;
   overflow-x: hidden;
 }
 #hangout-bar {
@@ -36,8 +36,7 @@ body, html {
 }
 #popup-container {
   width: 600px;
-  margin-top: 28px;
-  position: relative;
+  margin-top: 30px;
   top: 0;
   left: 0;
 }
@@ -81,8 +80,17 @@ body, html {
   left: 0;
 }
 
+#maps-container > h2 {
+  padding-left: 10px;
+  margin:12px 0;
+}
+
+#options-container {
+  padding: 0 10px;
+}
+
 #map-canvas {
-  width: 100%;
+  width: 600px;
   height: 250px;
 }
 
@@ -90,7 +98,7 @@ body, html {
   background-color: #eee;
   border-radius: 5px;
   height: 65px;
-  margin: 5px 0;
+  margin: 5px 0 5px 5px;
   clear: both;
   position: relative;
 }

--- a/js/modules/maps/map_controller.js
+++ b/js/modules/maps/map_controller.js
@@ -34,7 +34,9 @@ MapController.prototype.bindUI = function() {
     $('#hangouts-container').remove();
     $('#popup-open').remove();
     $('#maps-container')
+        .show()
         .css('width', $(window).width() + 'px')
+        .css('height', $(window).height() + 'px')
         .css('position', 'fixed')
         .css('left', '0')
         .css('top', '0')
@@ -52,19 +54,45 @@ MapController.prototype.bindUI = function() {
         .css('padding', '0 0 0 10px');
     $('body')
         .css('background', 'white url(/img/wood-bg.jpg)');
-    this.map.setZoom(3);
     
     $(window).resize(this.onResize.bind(this));
     
     // Lazy load the height.
     setTimeout(function() {
       this.onResize();
+      this._fitMarkers();  
     }.bind(this), 250);
   }
   else {
     $('#popup-open').click(this.onOpenAsWindow.bind(this));
   }
 };
+
+/**
+ * Calculates a bounding box around the currently shown markers and calls
+ * the map to adjust itself to these bounds.
+ */
+MapController.prototype._fitMarkers = function() {
+  var self = this;
+  var bounds = new google.maps.LatLngBounds();
+
+  $.each(this.markersCache, function(markerID) {
+    bounds.extend(self.markersCache[markerID].getPosition());  
+  });
+
+  this.map.fitBounds(bounds);
+}
+
+/**
+ * This callback should be called everytime the map view gets visible to
+ * to the user.
+ */
+MapController.prototype.onDisplay = function() {
+  // Delay the adjustments as some animation may still be running
+  setTimeout(function() {
+    this._fitMarkers();
+  }.bind(this), 600);
+}
 
 MapController.prototype.onResize = function() {
   $('#map-canvas')

--- a/js/popup_controller.js
+++ b/js/popup_controller.js
@@ -47,6 +47,7 @@ PopupController.prototype.onMenuItemClick = function(e) {
       break;
     case 'menu-maps':
       this.togglePage('maps');
+      this.map.onDisplay();
       break;
     case 'menu-options':
       this.togglePage('options');

--- a/js/popup_controller.js
+++ b/js/popup_controller.js
@@ -29,6 +29,7 @@ PopupController.prototype.init = function() {
 
 PopupController.prototype.bindUI = function() {
   $('#version').text('version ' + this.bkg.settings.version);
+  $('#' + this.currentPage + '-container').show();
   $('.menu-item').click(this.onMenuItemClick.bind(this));
   if (window.location.hash == '#window') {
     this.displayAsTab = true;
@@ -139,15 +140,11 @@ PopupController.prototype.relayout = function() {
  * Toggle the page from options and hangouts.
  */
 PopupController.prototype.togglePage = function(newpage) {
-  var goLeftBy = -600;
-  if (this.navigationPositions[newpage] < this.navigationPositions[this.currentPage]) {
-    goLeftBy = 600;
-  }
-  $('#' + this.currentPage + '-container').animate({left: goLeftBy, overflow: 'hidden'}, 500);
-  $('#menu-' + this.currentPage).toggleClass('selected');
+  $('#' + this.currentPage + '-container').fadeOut().slideUp();
+  $('#menu-' + this.currentPage).removeClass('selected');
   this.currentPage = newpage;
-  $('#' + this.currentPage + '-container').animate({left: 0, overflow: 'auto'}, 500);
-  $('#menu-' + this.currentPage).toggleClass('selected');
+  $('#' + this.currentPage + '-container').fadeIn().slideDown();
+  $('#menu-' + this.currentPage).addClass('selected');
   this.relayout();
 };
 

--- a/notification.html
+++ b/notification.html
@@ -3,11 +3,11 @@
 <head>
   <title>My Hangouts Circle Notifier</title>
   <link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
-  <link rel="stylesheet" type="text/css" href="/css/common.css" />
-  <link rel="stylesheet" type="text/css" href="/css/notification.css" />
-  <script type="text/javascript" src="/js/libs/jquery-1.7.1.min.js"></script>
-  <script type="text/javascript" src="/js/libs/jquery.tmpl.min.js"></script>
-  <script type="text/javascript" src="/js/modules/circle_notifier/notification_controller.js"></script>
+  <link rel="stylesheet" href="/css/common.css" />
+  <link rel="stylesheet" href="/css/notification.css" />
+  <script src="/js/libs/jquery-1.7.1.min.js"></script>
+  <script src="/js/libs/jquery.tmpl.min.js"></script>
+  <script src="/js/modules/circle_notifier/notification_controller.js"></script>
 </head>
 <body>
   <div id="notification-container">
@@ -33,7 +33,7 @@
     </div>
     {{/each}}
   </script>
-  <script type="text/javascript">
+  <script>
     var controller = new NotificationController();
     controller.init();
   </script>

--- a/popup.html
+++ b/popup.html
@@ -38,7 +38,7 @@
 		</div>    
     <div id="options-container" class="popup-page">
       <h2>Circle preferences</h2>
-      <select id="option-circles" data-placeholder="Choose your Circles..." multiple style="width: 100%;"></select>
+      <select id="option-circles" data-placeholder="Choose your Circles..." multiple style="width: 580px;"></select>
       <p><label for="option-circles-notify"><input id="option-circles-notify" type="checkbox" /> Notify me when a user in my circles above entered a hangout.</label></p>
       <h2>Hangout preferences</h2>
       <p><label for="option-hangout-window"><input id="option-hangout-window" type="checkbox" />Opens the hangout as a new window instead of in a new tab.</label></p>

--- a/popup.html
+++ b/popup.html
@@ -3,18 +3,18 @@
 <head>
   <title>My Hangouts World</title>
   <link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
-  <link rel="stylesheet" type="text/css" href="/css/common.css" />
-  <link rel="stylesheet" type="text/css" href="/css/chosen.css" />
-  <link rel="stylesheet" type="text/css" href="/css/popup.css" />
-  <script type="text/javascript" src="http://maps.google.com/maps/api/js?key=AIzaSyDnMniG_y2Fo35Tw28QnR4OeUTVBMXIWi4&sensor=true"></script>
-  <script type="text/javascript" src="/js/libs/jquery-1.7.1.min.js"></script>
-  <script type="text/javascript" src="/js/libs/jquery.tmpl.min.js"></script>
-  <script type="text/javascript" src="/js/libs/jquery.timeago.js"></script>
-  <script type="text/javascript" src="/js/libs/chosen.jquery.min.js"></script>
-  <script type="text/javascript" src="/js/libs/simplemarker.1.4.min.js"></script>
-  <script type="text/javascript" src="/js/modules/maps/map_controller.js"></script>
-  <script type="text/javascript" src="/js/modules/options/options_controller.js"></script>
-  <script type="text/javascript" src="/js/popup_controller.js"></script>
+  <link rel="stylesheet" href="/css/common.css" />
+  <link rel="stylesheet" href="/css/chosen.css" />
+  <link rel="stylesheet" href="/css/popup.css" />
+  <script src="http://maps.google.com/maps/api/js?key=AIzaSyDnMniG_y2Fo35Tw28QnR4OeUTVBMXIWi4&sensor=true"></script>
+  <script src="/js/libs/jquery-1.7.1.min.js"></script>
+  <script src="/js/libs/jquery.tmpl.min.js"></script>
+  <script src="/js/libs/jquery.timeago.js"></script>
+  <script src="/js/libs/chosen.jquery.min.js"></script>
+  <script src="/js/libs/simplemarker.1.4.min.js"></script>
+  <script src="/js/modules/maps/map_controller.js"></script>
+  <script src="/js/modules/options/options_controller.js"></script>
+  <script src="/js/popup_controller.js"></script>
 </head>
 <body>
   <div id="hangout-bar">
@@ -95,7 +95,7 @@
     </div>
     {{/each}}
   </script>
-  <script type="text/javascript">
+  <script>
     var popupController = new PopupController();
     popupController.init();
   </script>


### PR DESCRIPTION
Hey,

these changes take care of issue #25 (the displaced container bug). Apart from that, I changed these little things:
- Set the `margin` of `body` completely to zero. I did this because without it, there was a white border on the right side of the hangout-items. This just looked somehow broken (I think it looks better when the items are directly aligned to the border of the popup, especially because of the "slide-in" overlay).
- Dropped `position:relative` of the containers - it's not needed any more due to the bugfix listed above
- Added padding to the options container and maps heading - in order to compensate for the now missing body `margin`
- Set the maps canvas to a fixed with - the popup uses a fixed with anyway, this prevents potential bugs from happening (when creating the `google.maps.Map`)
- Adjusting the map to the currently shown markers upon loading - because it was kind of displaced in some occasions

Proposal (**not** part of this pull request): set `text-decoration` of `.button` to `none` - in my opinion this looks way better
