### PR TITLE
Constrain nubs to canvas.

### DIFF
--- a/js/modules/capture_moments/capture_gallery_filter.js
+++ b/js/modules/capture_moments/capture_gallery_filter.js
@@ -417,7 +417,6 @@ CaptureEffectsController.prototype.collectEffects = function() {
 			if (filter.length == 1) {
 				// Clone it and add to stack
 				clone = $.extend(true, {}, filter[0])
-				children = $(s).children('div')
 				filtersToApply.push(clone)
 			}
 		}
@@ -486,14 +485,14 @@ Filter.prototype.use = function(effectController, filterName, selectedIndex) {
     var y = nub.y * canvas.height;
     $('<div class="nub" id="nub' + i + '"></div>').appendTo('#nubs');
     var ondrag = (function(this_, nub) { return function(event, ui) {
-      var offset = $("#light").offset();
+      var offset = $("#canvasPreview").offset();
       console.log("here");
       this_[nub.name] = { x: ui.offset.left - offset.left, y: ui.offset.top - offset.top };
 			controller.effectsController.collectEffects();
     }; })(this, nub);
     $('#nub' + i).draggable({
       drag: ondrag,
-      //containment: 'parent',
+      containment: 'canvas',
       scroll: false
     }).css({ left: x, top: y });
     this[nub.name] = { x: x, y: y };


### PR DESCRIPTION
Nubs now constrained to canvas.

Need to rework how they function because if you apply a nub filter before applying one without nubs, the nubs disappear. So as it stands now, can only apply a single nubs filter and it should be the last one.

Working on a fix for that.
