### PR TITLE
Delete filter binding fix.

### DIFF
--- a/js/modules/capture_moments/capture_gallery_filter.js
+++ b/js/modules/capture_moments/capture_gallery_filter.js
@@ -143,11 +143,8 @@ CaptureEffectsController.prototype.onWindowResize = function() {
 };
 
 CaptureEffectsController.prototype.onEffectClose = function(e) {
-  console.log("closed");
-
 	$(e.target).parent().fadeOut();
-  // TODO: Cleanup
-	console.log("closed");
+	$(e.target).parent().remove();
 };
 
 CaptureEffectsController.prototype.onAddEffectClicked = function() {
@@ -155,6 +152,8 @@ CaptureEffectsController.prototype.onAddEffectClicked = function() {
   var newFilter = this.filterTemplate.tmpl({_id:id});
 	newFilter.insertBefore('.add-effect-btn');
 	this.renderEffects('#effects'+id);
+  $('.close').click(this.onEffectClose.bind(this));
+	
 };
 
 CaptureEffectsController.prototype.bindUI = function() {


### PR DESCRIPTION
Error was that the binding is for the present elements at the time.

At time of binding, no fx-panels exist and it doesn't get bound.

The fix is to call the binding at the end of the onEffectAdded call.
